### PR TITLE
서비스 로직 처리 시간 로깅 기능 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,11 +1,14 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
+import { APP_INTERCEPTOR } from "@nestjs/core";
 import Joi = require("joi");
 
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
-import { TodoServiceModule } from "./todo-service/todo-service.module";
+
 import AppConfig from "./config/app.config";
+import { LoggingInterceptor } from "./interceptor/logging.interceptor";
+import { TodoServiceModule } from "./todo-service/todo-service.module";
 
 @Module({
   imports: [
@@ -22,6 +25,12 @@ import AppConfig from "./config/app.config";
     TodoServiceModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: LoggingInterceptor,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/interceptor/logging.interceptor.ts
+++ b/src/interceptor/logging.interceptor.ts
@@ -1,0 +1,30 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { tap } from "rxjs/operators";
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const requestIncomingTime = Date.now();
+
+    return next.handle().pipe(
+      tap(() => {
+        const durationTime = Date.now() - requestIncomingTime;
+
+        const request = context.switchToHttp().getRequest();
+        const response = context.switchToHttp().getResponse();
+
+        const httpStatusCode = response.statusCode;
+        const clientIP = request.ip;
+        const httpMethod = request.method;
+        const url = context.switchToHttp().getRequest().url;
+
+        const logFormat = `Mock service: ${new Date(
+          requestIncomingTime
+        ).toUTCString()} |   ${httpStatusCode}   |   ${durationTime}ms      |   ${clientIP}     |   ${httpMethod}   ${url}`;
+
+        console.log(logFormat);
+      })
+    );
+  }
+}


### PR DESCRIPTION
# 변경 내역

1. Client의 HTTP Request에 대한 정보를 콘솔에 출력하는 기능을 추가

# 변경 사유

1. K8S내 처리 시간 병목 지점 확인을 위함

# 테스트 방법

1. QA배포후 요청에 대한 Log가 콘솔에 출력되는지 확인합니다.