### PR TITLE
README.md 파일만을 보고 프로젝트 실행 가능하게 설명 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@
 
 ## 빠른 시작
 
-### 개발 환경
+`docker-compose up -d` 명령어를 입력해 Docker container를 실행합니다.
+
+## 개발 환경
 
 1. .env.dev 파일에 특이사항이 있는 경우 수정합니다.
 1. VSCode 디버그 창 내부에 있는 NestJS start 버튼을 눌러 시작합니다.
 
-### QA/production 환경
+## QA/production 환경
 
 1. README.md 파일 내 환경변수 표를 참고해 자신의 서버 환경에 알맞은 OS 환경변수를 설정합니다.
 1. `npm i && npm run start:prod` 명령을 이용해서 mock service를 시작합니다.


### PR DESCRIPTION
# 변경 내역

1. README.md 파일내에 docker 명령어를 사용해 즉시 프로젝트 실행 방법 설명 추가

# 변경 사유

1. 추후 포트폴리오를 위해 즉시 프로젝트를 로컬에서 git clone이후 실행해야할 필요성 생김

# 테스트 방법

1. 기존 mock 서비스의 기능이 API Gateway를 통해 정상 응답하는지 확인합니다.